### PR TITLE
fixed subprocess call to work on all systems

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ gi.require_version('Notify', '0.7')
 from locale import atof, setlocale, LC_NUMERIC
 from gi.repository import Notify
 from itertools import islice
-from subprocess import Popen, PIPE, check_call, CalledProcessError
+from subprocess import check_output, check_call, CalledProcessError
 from ulauncher.api.client.Extension import Extension
 from ulauncher.api.client.EventListener import EventListener
 from ulauncher.api.shared.event import KeywordQueryEvent, ItemEnterEvent
@@ -105,8 +105,7 @@ def get_process_list():
     """
     env = os.environ.copy()
     env['COLUMNS'] = '200'
-    process = Popen(['top', '-bn1', '-cu', os.getenv('USER')], stdout=PIPE, env=env)
-    out = process.communicate()[0].decode('utf8')
+    out = check_output(['ps', '-eo', 'pid,%cpu,cmd', '--sort', '-%cpu'], env=env).decode('utf8')
     for line in out.split('\n'):
         col = line.split()
         try:


### PR DESCRIPTION
Changed the use of 'top' to the use of 'ps', because the top command did not work for on systems with custom top configuration file.
See [this](https://stackoverflow.com/questions/23989095/how-do-you-extract-only-the-cpu-usage-and-the-process-names-columns-from-top-com) thread for more info.

Also replaced the Popen (incl.PIPE) for a simple check_output command.

Sorry forgot to adapt the column numbers, see the comment below. However I don't know how to adapt them quickly so I hope you can very quickly adapt them in line number 119-121 while reviewing the merge...